### PR TITLE
Fix crashes in WriteXY::write() and gathervImpl().

### DIFF
--- a/src/Parallel.cc
+++ b/src/Parallel.cc
@@ -133,7 +133,7 @@ void gathervImpl(
 #ifdef USE_MPI
     const int type_size = sizeof(T);
     int sendcount = type_size * numx;
-    std::vector<int> recvcount, disp;
+    std::vector<int> recvcount(1, 0), disp(1, 0);
     if (mype == 0) {
         recvcount.resize(numpe);
         for (int pe = 0; pe < numpe; ++pe) {

--- a/src/WriteXY.cc
+++ b/src/WriteXY.cc
@@ -38,11 +38,11 @@ void WriteXY::write(
 
     int gnumz = numz;
     Parallel::globalSum(gnumz);
-    gnumz = (mype == 0 ? gnumz : 0);
-    vector<int> penumz(mype == 0 ? numpe : 0);
+    gnumz = (mype == 0 ? gnumz : 1);
+    vector<int> penumz((mype == 0 ? numpe : 1), 0);
     Parallel::gather(numz, &penumz[0]);
 
-    vector<double> gzr(gnumz), gze(gnumz), gzp(gnumz);
+    vector<double> gzr(gnumz, 0), gze(gnumz, 0), gzp(gnumz, 0);
     Parallel::gatherv(&zr[0], numz, &gzr[0], &penumz[0]);
     Parallel::gatherv(&ze[0], numz, &gze[0], &penumz[0]);
     Parallel::gatherv(&zp[0], numz, &gzp[0], &penumz[0]);


### PR DESCRIPTION
Fix crashes when the number of MPI processes is greater than 1. The
problem appears to come from taking the address of the first element of
zero-length std::vectors during collective operations. The problematic
arrays are located on MPI processes with MPI_COMM_WORLD_RANK != 0.