### PR TITLE
Add gcc unroll optimizations in advPosHalf and calcEnergy

### DIFF
--- a/src/Hydro.cc
+++ b/src/Hydro.cc
@@ -318,6 +318,7 @@ void Hydro::advPosHalf(
     double dth = 0.5 * dt;
 
     #pragma ivdep
+    #pragma GCC unroll 2
     for (int p = pfirst; p < plast; ++p) {
         pxp[p] = px0[p] + pu0[p] * dth;
     }
@@ -478,6 +479,7 @@ void Hydro::calcEnergy(
 
     const double fuzz = 1.e-99;
     #pragma ivdep
+    #pragma GCC unroll 2
     for (int z = zfirst; z < zlast; ++z) {
         ze[z] = zetot[z] / (zm[z] + fuzz);
     }


### PR DESCRIPTION
Unrolling the small loops in advPosHalf and calcEnergy leads to an improved cycles per instructions retired rate in these loops and hence slightly faster compute times.

On an i9-12900, looking using test/sedovbig/sedovbig.pnt I'm seeing improvements in the hydro cycle run time of:

2 threads:  0.2%
4 threads:  0.5%
8 threads:  1.6%
16 threads: 2.1%